### PR TITLE
openwrt/lede/feeds/luciappapfreewifidog.tmp/info/.files-packageinfo.mk:1: *** 目标模式不含有“%”。 停止。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ LUCI_TITLE:=LuCI support for ApFree WifiDog
 LUCI_DEPENDS:=+apfree_wifidog
 LUCI_PKGARCH:=all
 
-include ../../luci.mk
+include $(TOPDIR)/feeds/luci/luci.mk
 
+$(eval $(call PackageDir,luciappapfreewifidog,luciappapfreewifidog,))
+$(eval $(call PackageDir,luci-app-apfree-wifidog,luc
 # call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
ming@ming-PC:~/openwrt/lede$ ./scripts/feeds update -a
*
*
Create index file './feeds/luciappapfreewifidog.index' 
grep: feeds/luciappapfreewifidog/Makefile:#: 没有那个文件或目录
grep: call: 没有那个文件或目录
grep: BuildPackage: 没有那个文件或目录
grep: OpenWrt: 没有那个文件或目录
grep: buildroot: 没有那个文件或目录
grep: signature/Makefile: 没有那个文件或目录
/home/ming/openwrt/lede/feeds/luciappapfreewifidog.tmp/info/.files-packageinfo.mk:1: *** 目标模式不含有“%”。 停止。


ming@ming-PC:~/openwrt/lede$ ./scripts/feeds install -a
Installing all packages from feed luciappapfreewifidog.
Ignoring feed 'luciappapfreewifidog' - index missing
Ignoring feed 'luciappapfreewifidog' - index missing
Ignoring feed 'luciappapfreewifidog' - index missing

一直出现这个： *** 目标模式不含有“%”。 停止。
在Makefile添加了
include $(TOPDIR)/feeds/luci/luci.mk

$(eval $(call PackageDir,luciappapfreewifidog,luciappapfreewifidog,))
$(eval $(call PackageDir,luci-app-apfree-wifidog,luci-app-apfree-wifidog,))
就不出现这个提示，但make menuconfig里没有luci-app-apfree-wifidog